### PR TITLE
Update AWS java sdk version to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:jre-alpine
-MAINTAINER Damien Metzler <dmetzler@nuxeo.com>
-MAINTAINER Remi Cattiau <remi@cattiau.com>
-MAINTAINER Morgan Christiansson <docker@mog.se>
+LABEL maintainer="Damien Metzler <dmetzler@nuxeo.com>"
+LABEL maintainer="Remi Cattiau <remi@cattiau.com>"
+LABEL maintainer="Morgan Christiansson <docker@mog.se>"
 
 ADD target/*-jar-with-dependencies.jar /usr/share/aws-smtp-relay/aws-smtp-relay.jar
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,14 +5,14 @@
 
     <groupId>com.loopingz</groupId>
     <artifactId>aws-smtp-relay</artifactId>
-    <version>1.3.0</version>
+    <version>1.4.0</version>
 
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk-bom</artifactId>
-                <version>1.11.449</version>
+                <version>1.11.838</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -34,12 +34,12 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-dynamodb</artifactId>
-            <version>1.11.564</version>
+            <version>1.11.838</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-ses</artifactId>
-            <version>1.11.564</version>
+            <version>1.11.838</version>
         </dependency>
         <dependency>
             <groupId>com.sun.mail</groupId>


### PR DESCRIPTION
Updating the AWS java SDK versions to latest so that we have support for IAM role based service accounts.

1. https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-bom
2. https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-dynamodb
3. https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-ses

Primarily interested in `aws-java-sdk-ses`, but decided to refresh all of them at the same time. Also fixed some deprecated syntax in Dockerfile.

Built, ran locally and confirmed startup. Also built a docker image and pushed it up to ECR (as `560248293975.dkr.ecr.us-west-2.amazonaws.com/airflow:aws-smtp-relay-coda-1.4.0`)

PTAL @nigelellis 

Thanks,
Hari.